### PR TITLE
Fix wkhtml "TypeError: Attempting to change value of a readonly property."

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -73,12 +73,15 @@ function observer<VC extends VueClass<Vue>>(Component: VC | ComponentOptions<Vue
 		$destroy.apply(this);
 	};
 
-	Object.defineProperty(ExtendedComponent, 'name', {
-		writable: false,
-		value: name,
-		enumerable: false,
-		configurable: false,
-	});
+	const extendedComponentNamePropertyDescriptor = Object.getOwnPropertyDescriptor(ExtendedComponent, 'name') || {};
+	if (extendedComponentNamePropertyDescriptor.configurable === true) {
+		Object.defineProperty(ExtendedComponent, 'name', {
+			writable: false,
+			value: name,
+			enumerable: false,
+			configurable: false,
+		});
+	}
 
 	return ExtendedComponent;
 }


### PR DESCRIPTION
When using with wkhtmltopdf (0.12.4) `wkhtmltopdf --debug-javascript http://host/page file.pdf`, it output the error `TypeError: Attempting to change value of a readonly property`.

My investigations leads me to find that Webkit doesn't consider `ExtendedComponent.name` as configurable, so I made the property definition conditional.

It works fine on Firefox & Chrome.

**Context**
Observer is set in traditionnal way.