### PR TITLE
flx:delete name

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -24,7 +24,7 @@ function observer<VC extends VueClass<Vue>>(Component: VC | ComponentOptions<Vue
 	const dataDefinition = originalOptions.data;
 	const options = {
 		...originalOptions,
-		name,
+		// name, 
 		data(vm: Vue) {
 			return collectDataForVue(vm || this, dataDefinition);
 		},


### PR DESCRIPTION
取 class 的 name 属性 在webpack 压缩后 的 name 是无效的。或者说不准确的。而且会覆盖 
@Component({
  name: "PageSignin",
  components: {},
})
中定义的 name 值，所以 建议 注释掉。这个问题排查了好多地方才发现是 这里覆盖了。