### PR TITLE
Migrate travis-ci to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js v12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+           path: ~/.npm
+           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+           restore-keys: |
+             ${{ runner.OS }}-node-
+             ${{ runner.OS }}-
+      - name: Install dependencies
+      - run: npm ci
+      - name: Run unit test
+      - run: npm run lint
+      - name: Codecov
+      - run: npm run codecov


### PR DESCRIPTION
> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.

Migrate our CI Infra from `travis-ci` to `Github Actions` !